### PR TITLE
Feat/add geth init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Docker compose
+*.env
+*.env.*
+
+# Datadir
+*-data
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,20 +1,20 @@
-
+version: '3.9'
 services:
+  # Codex Frontend
   codex-frontend:
     image: codexstorage/codex-frontend:latest
+    pull_policy: always
+    environment:
+      - codex_url=http://codex:8080
     ports:
       - 3000:80
-    environment:
-     - codex_url=http://my-codex-node:8080
     depends_on:
-      - my-codex-node
+      - codex
 
-  my-codex-node:
+  # Codex Node
+  codex:
     image: codexstorage/nim-codex:latest-dist-tests
-    ports:
-      - 8080:8080/tcp # API port
-      - 8090:8090/udp # Discovery port
-      - 8070:8070/tcp # Listen port
+    pull_policy: always
     environment:
       - CODEX_LOG_LEVEL=Trace
       - CODEX_API_PORT=8080
@@ -24,30 +24,50 @@ services:
       - CODEX_BOOTSTRAP_NODE=spr:CiUIAhIhAlrt4nrtZA6BtsyuUS2lJoZQQaRjItOCvdbNBWAwjpXNEgIDARo8CicAJQgCEiECWu3ieu1kDoG2zK5RLaUmhlBBpGMi04K91s0FYDCOlc0QpunsqgYaCwoJBJ_f5lWRAnVOKkcwRQIhANP3hAuwJpazzbj6kLlB2QNfAMeL6mbaRDBigZHVzJvdAiBuyNcpvulJ7O8D4enYhASY05UfxBLUl0VMHJptwWv6KQ
       - NAT_PUBLIC_IP_AUTO=https://ip.codex.storage
       - NAT_IP_AUTO=false
-
       - CODEX_ETH_PROVIDER=ws://my-geth:8083
       - CODEX_PERSISTENCE=true
       - CODEX_VALIDATOR=false
       - CODEX_MARKETPLACE_ADDRESS=0x92F09Aa59DcCb892a9f5406DDd9c0b98f02EA57e
-
       - PRIV_KEY=<YOUR-KEY-HERE>
+    ports:
+      - 8080:8080/tcp # API port
+      - 8090:8090/udp # Discovery port
+      - 8070:8070/tcp # Listen port
     volumes:
-      - ./datadir:/datadir
+      - ./codex-data:/datadir
     depends_on:
-      - my-geth
+      - geth
 
-  my-geth:
-    image: codexstorage/dist-tests-geth:latest
+  # Geth init
+  geth-init:
+    image: ethereum/client-go:v1.13.5
+    entrypoint: /bin/sh
+    command: -c '[ -d /data/geth/chaindata ] && echo "Genesis block already created" || geth init --datadir /data /data/genesis.json'
+    volumes:
+      - ./geth-data:/data
+      - ./genesis.json:/data/genesis.json
+
+  # Get
+  geth:
+    image: ethereum/client-go:v1.13.5
     environment:
-      - ENABLE_MINER=1
-      - UNLOCK_START_INDEX=0
-      - UNLOCK_NUMBER=1
-      - GETH_ARGS=--http.addr 0.0.0.0 --http.port 30000 --port 8081 --discovery.port 8080 --ipcdisable --syncmode full --authrpc.port 8082 --ws --ws.addr 0.0.0.0 --ws.port 8083
-
-  # Not needed when geth node is bootstrapped.
-  # apply-contracts:
-  #   image: codexstorage/codex-contracts-eth:sha-1854dfb-dist-tests
-  #   environment:
-  #     - DISTTEST_NETWORK_URL=http://my-geth:30000
-  #     - HARDHAT_NETWORK=codexdisttestnetwork
-  #     - KEEP_ALIVE=1
+      - GETH_DATADIR=/data
+      - GETH_NETWORKID=789987
+      - GETH_SYNCMODE=full
+      # - GETH_NAT=any
+      # - GETH_NAT=extip:1.1.1.1
+      # - GETH_PORT=
+      # - GETH_DISCOVERY_PORT=
+      - GETH_VERBOSITY=3
+      - GETH_HTTP=true
+      - GETH_HTTP_PORT=8545
+      - GETH_WS=true
+      - GETH_WS_PORT=8546
+      - GETH_BOOTNODES=enode://cff0c44c62ecd6e00d72131f336bb4e4968f2c1c1abeca7d4be2d35f818608b6d8688b6b65a18f1d57796eaca32fd9d08f15908a88afe18c1748997235ea6fe7@159.223.243.50:40010,enode://ea331eaa8c5150a45b793b3d7c17db138b09f7c9dd7d881a1e2e17a053e0d2600e0a8419899188a87e6b91928d14267949a7e6ec18bfe972f3a14c5c2fe9aecb@68.183.245.13:40030,enode://4a7303b8a72db91c7c80c8fb69df0ffb06370d7f5fe951bcdc19107a686ba61432dc5397d073571433e8fc1f8295127cabbcbfd9d8464b242b7ad0dcd35e67fc@174.138.127.95:40020,enode://36f25e91385206300d04b95a2f8df7d7a792db0a76bd68f897ec7749241b5fdb549a4eecfab4a03c36955d1242b0316b47548b87ad8291794ab6d3fecda3e85b@64.225.89.147:40040,enode://2e14e4a8092b67db76c90b0a02d97d88fc2bb9df0e85df1e0a96472cdfa06b83d970ea503a9bc569c4112c4c447dbd1e1f03cf68471668ba31920ac1d05f85e3@170.64.249.54:40050
+    ports:
+      - 8545:8545/tcp # HTTP-RPC
+      - 8546:8546/udp # WS-RPC
+    volumes:
+      - ./geth-data:/data
+    depends_on:
+      - geth-init

--- a/genesis.json
+++ b/genesis.json
@@ -1,0 +1,34 @@
+{
+    "config": {
+      "chainId": 789987,
+      "homesteadBlock": 0,
+      "eip150Block": 0,
+      "eip155Block": 0,
+      "eip158Block": 0,
+      "byzantiumBlock": 0,
+      "constantinopleBlock": 0,
+      "petersburgBlock": 0,
+      "istanbulBlock": 0,
+      "muirGlacierBlock": 0,
+      "berlinBlock": 0,
+      "londonBlock": 0,
+      "arrowGlacierBlock": 0,
+      "grayGlacierBlock": 0,
+      "clique": {
+        "period": 10,
+        "epoch": 30000
+      }
+    },
+    "difficulty": "1",
+    "gasLimit": "8000000",
+    "extradata": "0x00000000000000000000000000000000000000000000000000000000000000003a39904b71595608524274bfd8c20fcfd9e772360000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "alloc": {
+      "0x3a39904b71595608524274bfd8c20fcfd9e77236": { "balance": "100000000000000000000000000" },
+      "0x28840F2a7869E1dBe1Ef90Db08Bf50c74614c37e": { "balance": "100000000000000000000000000" },
+      "0x1fa74c3DD6050799BA74D4363D6036E22FAF05F6": { "balance": "100000000000000000000000000" },
+      "0x7f60982Ad4eF64FC42455Ba666fcFc8DBdDf2F1D": { "balance": "100000000000000000000000000" },
+      "0x7558f20595678c78961a61bE6F9BF3615C1b1C60": { "balance": "100000000000000000000000000" },
+      "0x4Fed456c1b4F1F4cA085c18475feE2E3cdE056f8": { "balance": "100000000000000000000000000" },
+      "0xa1671207A037a1133018eaaCb0DA51b2FE789d35": { "balance": "100000000000000000000000000" }
+    }
+  }


### PR DESCRIPTION
@benbierens, this PR adds some improvements for Docker Compose configuration
1. `.gitignore` with Docker Compose related data added
2. A prefix `my-` was removed and containers renamed, now at run we see the following in the list
   ```shell
   codex-testnet-starter-codex-frontend-1
   codex-testnet-starter-geth-1
   ```
3. Added Codex Testnet `genesis.json` file
4. Added `geth-init` container which is used just to create genesis block
5. Updated `geth` container to use latest release and
    - Configuration switched to the environment variables
    - Added basic configuration
    - NAT related configuration is commented out for now
    - Enabled HTTP and WS
    - Added Codex Testnet Geth bootstrap nodes
6. For Codex containers added `pull_policy: always` until we will switch to the release

Closes https://github.com/codex-storage/infra-codex/issues/111