### PR TITLE
chore: add background flag for docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Using the Testnet Starter, you can run a (mostly preconfigured) Codex node on yo
 
  5. Run local nodes
     ```shell
-    docker-compose up
+    docker-compose up -d
     ```
 
  6. Setup port forwarding on your router for Codex, based on defined values


### PR DESCRIPTION
If launched the docker-compose as described, then it runs attached to the console, and the "How to stop" does not really make sense as you need to `CTRL+C/SIGINT` to exit... 