### PR TITLE
Minor changes to Linux scripts

### DIFF
--- a/scripts/linux/download.sh
+++ b/scripts/linux/download.sh
@@ -3,3 +3,4 @@ tar -xvzf codex-v0.1.0-linux-amd64.tar.gz
 
 chmod +x codex-v0.1.0-linux-amd64
 
+echo "Codex binary saved to ${PWD}/codex-v0.1.0-linux-amd64"

--- a/scripts/linux/generate.sh
+++ b/scripts/linux/generate.sh
@@ -1,1 +1,12 @@
-curl -sX POST https://api.blockcypher.com/v1/eth/main/addrs
+#!/usr/bin/env bash
+set -e
+
+echo "Generating private key."
+
+response=$(curl -sX POST https://api.blockcypher.com/v1/eth/main/addrs)
+echo -n "${response}" | sed -n 's/^\s*"private": *"\(.*\)",$/\1/p' > ./eth.key
+address=$(echo -n "${response}" | sed -n 's/^\s*"address": *"\(.*\)"$/0x\1/p')
+chmod 600 ./eth.key
+
+echo " * your private key has been saved to ${PWD}/eth.key"
+echo " * your ethereum address is ${address}"

--- a/scripts/linux/run_client.sh
+++ b/scripts/linux/run_client.sh
@@ -1,4 +1,20 @@
-BOOTSPR=UPDATE ME
+#!/bin/env bash
+set -e
+
+if [ -z "$LOCALIP" ]; then
+  echo "LOCALIP is not defined. Please set it to your IP address."
+  exit 1
+fi
+
+if [ -z "$BOOTSPR" ]; then
+  echo "BOOTSPR is not defined. Please set it to the bootstrap node SPR."
+  exit 1
+fi
+
+if [ ! -f eth.key ]; then
+  echo "eth.key does not exist. Please run generate.sh to create it."
+  exit 1
+fi
 
 ./codex-v0.1.0-linux-amd64 \
   --data-dir=data_client \
@@ -11,9 +27,4 @@ BOOTSPR=UPDATE ME
   persistence \
   --eth-private-key=eth.key \
   --eth-provider=https://rpc.testnet.codex.storage \
-  --marketplace-address=0x9C88D67c7C745D2F0A4E411c18A6a22c15b37EaA \
-  &
-
-sleep 5
-
-curl http://localhost:8180/api/codex/v1/debug/info
+  --marketplace-address=0x9C88D67c7C745D2F0A4E411c18A6a22c15b37EaA


### PR DESCRIPTION
A few suggested improvements to:
1. make the ethereum key/address generation process simpler/clearer;
2. make run_client a bit more idiot proof (remove defaults which won't work, force user to set vars);
3. don't launch the Codex client on the background.
