### PR TITLE
Fix Generate.sh Script

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -8,5 +8,8 @@ echo -n "${response}" | grep -o '"private":.*"' | cut -d'"' -f4 > ./eth.key
 address=$(echo -n "${response}" | grep -o '"address":.*"' | cut -d'"' -f4)
 chmod 600 ./eth.key
 
+# Read the address from the file
+address=$(cat ./eth.address)
+
 echo " * your private key has been saved to ${PWD}/eth.key"
 echo " * your ethereum address is 0x${address}"


### PR DESCRIPTION
Fix to `generate.sh` script to read public Ethereum address from `eth.address` file properly.