### PR TITLE
Switch key generation to own service

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
 set -e
 
+# Variables
+key_file="eth.key"
+address_file="eth.address"
+
+# Generate
 echo "Generating private key..."
 
-response=$(curl -sX POST https://api.blockcypher.com/v1/eth/main/addrs)
-echo -n "${response}" | grep -o '"private":.*"' | cut -d'"' -f4 > ./eth.key
-echo -n "${response}" | grep -o '"address":.*"' | cut -d'"' -f4 > ./eth.address
-chmod 600 ./eth.key
+response=$(curl -s https://key.codex.storage)
+awk -F ': ' '/private/ {print $2}' <<<"${response}" >"${key_file}"
+awk -F ': ' '/address/ {print $2}' <<<"${response}" >"${address_file}"
 
-# Read the address from the file
-address=$(cat ./eth.address)
+# Permissions
+chmod 600 "${key_file}"
 
-echo " * your private key has been saved to ${PWD}/eth.key"
-echo " * your ethereum address has been saved to ${PWD}/eth.address"
-echo " * your ethereum address is 0x${address}"
+# Show
+address=$(cat ${address_file})
+echo " * your private key has been saved to ${PWD}/${key_file}"
+echo " * your ethereum address has been saved to ${PWD}/${address_file}"
+echo " * your ethereum address is ${address}"

--- a/scripts/windows/generate.bat
+++ b/scripts/windows/generate.bat
@@ -1,13 +1,18 @@
 @echo off
 setlocal enabledelayedexpansion
 
+:: Variables
+set key_file="%cd%\eth.key"
+set address_file="%cd%\eth.address"
+
+:: Generate
 echo Generating private key...
 
 :: Use PowerShell to make the API call and process the response
-powershell -Command "& { $response = Invoke-RestMethod -Uri 'https://api.blockcypher.com/v1/eth/main/addrs' -Method Post; $privateKey = $response.private; $address = $response.address;  $privateKey | Out-File -Encoding ASCII -FilePath '.\eth.key'; $address | Out-File -Encoding ASCII -FilePath '.\eth.address'; Write-Host ' * your private key has been saved to %cd%\eth.key'; Write-Host ' * your address has been saved to %cd%\eth.address'; Write-Host (' * your ethereum address is 0x' + $address); }"
+powershell -Command "& { $response = Invoke-RestMethod -Uri 'https://key.codex.storage/json'; $privateKey = $response.private; $address = $response.address; $privateKey | Out-File -Encoding ASCII -FilePath '%key_file%'; $address | Out-File -Encoding ASCII -FilePath '%address_file%'; Write-Host ' * your private key has been saved to %key_file%'; Write-Host ' * your address has been saved to %address_file%'; Write-Host (' * your ethereum address is ' + $address); }"
 
 :: Set file permissions to read-only for the current user
-icacls .\eth.key /inheritance:r
-icacls .\eth.key /grant:r %USERNAME%:F
+icacls %cd%\%key_file% /inheritance:r >nul 2>&1
+icacls %cd%\%key_file% /grant:r %USERNAME%:F >nul 2>&1
 
 exit /b 0


### PR DESCRIPTION
We just deployed own key generation service https://github.com/codex-storage/infra-codex/issues/199, which is available in the following ways
```shell
# Full
curl https://key.codex.storage

# JSON
curl https://key.codex.storage/json

# Minimal
curl https://key.codex.storage/m
```

PR updates key generation scripts accordingly and some small refactoring/prettifying was performed.