### PR TITLE
Use multiple bootstrap nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ eth.address
 eth.key
 
 .DS_Store
+
+# Codex artifacts
+codex-v*

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -78,6 +78,7 @@ for BINARY_NAME in "${BINARY_NAMES[@]}"; do
     echo "Downloading SHA256 checksum for ${FILE_NAME}..."
     if ! download_file "$CHECKSUM_URL" "${FILE_NAME}.sha256"; then
         echo "Checksum download failed for ${FILE_NAME}"
+        echo "Try to use 'DOWNLOAD=online ./`basename "$0"`' instead."
         exit 1
     fi
     echo

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -29,7 +29,7 @@ download_file() {
     local output_file="$2"
 
     if command -v curl &> /dev/null; then
-        curl -L -o "$output_file" "$url"
+        curl --max-time 300 --connect-timeout 5 -L -o "$output_file" "$url"
     elif command -v wget &> /dev/null; then
         wget -O "$output_file" "$url"
     else
@@ -48,8 +48,13 @@ else
     ARCHIVE_EXT=".tar.gz"
     EXE_EXT=""
 fi
-VERSION="v0.1.6"
-BASE_URL="http://192.168.88.253:8080"
+
+if [[ "${NETWORK}" == "workshop" && -z "${DOWNLOAD}" ]]; then
+    BASE_URL="http://192.168.88.253:8080"
+else
+    BASE_URL="https://github.com/codex-storage/nim-codex/releases/download/${VERSION}"
+fi
+
 EXTRACT_DIR="./"
 # Use BINARY_NAMES=("codex" "codex-prover") to also download/verify/extract prover binary
 BINARY_NAMES=("codex")
@@ -64,7 +69,7 @@ for BINARY_NAME in "${BINARY_NAMES[@]}"; do
     echo "Downloading ${FILE_NAME}..."
     if ! download_file "$DOWNLOAD_URL" "$FILE_NAME"; then
         echo "Download failed for ${FILE_NAME}"
-        echo "Try 'download_online.sh' instead."
+        echo "Try to use 'DOWNLOAD=online ./`basename "$0"`' instead."
         exit 1
     fi
     echo
@@ -73,7 +78,6 @@ for BINARY_NAME in "${BINARY_NAMES[@]}"; do
     echo "Downloading SHA256 checksum for ${FILE_NAME}..."
     if ! download_file "$CHECKSUM_URL" "${FILE_NAME}.sha256"; then
         echo "Checksum download failed for ${FILE_NAME}"
-        echo "Try 'download_online.sh' instead."
         exit 1
     fi
     echo

--- a/scripts/download_online.sh
+++ b/scripts/download_online.sh
@@ -78,6 +78,7 @@ for BINARY_NAME in "${BINARY_NAMES[@]}"; do
     echo "Downloading SHA256 checksum for ${FILE_NAME}..."
     if ! download_file "$CHECKSUM_URL" "${FILE_NAME}.sha256"; then
         echo "Checksum download failed for ${FILE_NAME}"
+        echo "Try to use 'DOWNLOAD=online ./`basename "$0"`' instead."
         exit 1
     fi
     echo

--- a/scripts/download_online.sh
+++ b/scripts/download_online.sh
@@ -29,7 +29,7 @@ download_file() {
     local output_file="$2"
 
     if command -v curl &> /dev/null; then
-        curl -L -o "$output_file" "$url"
+        curl --max-time 300 --connect-timeout 5 -L -o "$output_file" "$url"
     elif command -v wget &> /dev/null; then
         wget -O "$output_file" "$url"
     else
@@ -48,8 +48,13 @@ else
     ARCHIVE_EXT=".tar.gz"
     EXE_EXT=""
 fi
-VERSION="v0.1.6"
-BASE_URL="https://github.com/codex-storage/nim-codex/releases/download/${VERSION}"
+
+if [[ "${NETWORK}" == "workshop" && -z "${DOWNLOAD}" ]]; then
+    BASE_URL="http://192.168.88.253:8080"
+else
+    BASE_URL="https://github.com/codex-storage/nim-codex/releases/download/${VERSION}"
+fi
+
 EXTRACT_DIR="./"
 # Use BINARY_NAMES=("codex" "codex-prover") to also download/verify/extract prover binary
 BINARY_NAMES=("codex")
@@ -64,6 +69,7 @@ for BINARY_NAME in "${BINARY_NAMES[@]}"; do
     echo "Downloading ${FILE_NAME}..."
     if ! download_file "$DOWNLOAD_URL" "$FILE_NAME"; then
         echo "Download failed for ${FILE_NAME}"
+        echo "Try to use 'DOWNLOAD=online ./`basename "$0"`' instead."
         exit 1
     fi
     echo

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -6,7 +6,8 @@ key_file="eth.key"
 address_file="eth.address"
 url=https://key.codex.storage
 
-# Generate
+# Generate remote
+generate_remote() {
 echo "Generating private key from remote <${url}>..."
 
 response=$(curl -s ${url})
@@ -21,3 +22,22 @@ address=$(cat ${address_file})
 echo " * your private key has been saved to ${PWD}/${key_file}"
 echo " * your ethereum address has been saved to ${PWD}/${address_file}"
 echo " * your ethereum address is ${address}"
+}
+
+# Use user provided private key
+user_private_key() {
+  # Create file with required permissions
+  echo "${ETH_PRIVATE_KEY}" >"${key_file}"
+  chmod 600 "${key_file}"
+
+  echo "Using provided private key..."
+  echo " * your private key has been saved to ${PWD}/${key_file}"
+  echo " * please use your key address to get the tokens"
+}
+
+# Save keyrair
+if [[ -z "${ETH_PRIVATE_KEY}" ]]; then
+  generate_remote
+else
+  user_private_key
+fi

--- a/scripts/run_client.sh
+++ b/scripts/run_client.sh
@@ -12,31 +12,12 @@ if [ -z "$LOCALIP" ]; then
 fi
 echo "LOCAL IP: ${LOCALIP}"
 
-if [ -z "$BOOTSPR" ]; then
-  if [ "${NETWORK}" == "workshop" ]; then
-    # Local network SPR (Workshop NUC):
-    BOOTSPR="spr:CiUIAhIhAnBsex_7L5xKJQpmAuOtubQEtKsgCOXE2vaJoTJXrprbEgIDARo8CicAJQgCEiECcGx7H_svnEolCmYC4625tAS0qyAI5cTa9omhMleumtsQnbm0tAYaCwoJBMCoWP2RAh-aKkcwRQIhANjwAV9DGFe4zcMUEHjuTsGWAPc7WB7uoSS86HATwouqAiA8dFhsALCSLsQbSOPF1j7NF643oEmPEJAwU9dIwjM6TA"
-  else
-    # Cloud-Node-01 SPR:
-    BOOTSPR="spr:CiUIAhIhAiJvIcA_ZwPZ9ugVKDbmqwhJZaig5zKyLiuaicRcCGqLEgIDARo8CicAJQgCEiECIm8hwD9nA9n26BUoNuarCEllqKDnMrIuK5qJxFwIaosQ3d6esAYaCwoJBJ_f8zKRAnU6KkYwRAIgM0MvWNJL296kJ9gWvfatfmVvT-A7O2s8Mxp8l9c8EW0CIC-h-H-jBVSgFjg3Eny2u33qF7BDnWFzo7fGfZ7_qc9P"
-    # All Codex Testnet Cloud Bootstrap Node SPRs:
-    # BOOTSPR="spr:CiUIAhIhAiJvIcA_ZwPZ9ugVKDbmqwhJZaig5zKyLiuaicRcCGqLEgIDARo8CicAJQgCEiECIm8hwD9nA9n26BUoNuarCEllqKDnMrIuK5qJxFwIaosQ3d6esAYaCwoJBJ_f8zKRAnU6KkYwRAIgM0MvWNJL296kJ9gWvfatfmVvT-A7O2s8Mxp8l9c8EW0CIC-h-H-jBVSgFjg3Eny2u33qF7BDnWFzo7fGfZ7_qc9P"
-    # BOOTSPR="spr:CiUIAhIhAyUvcPkKoGE7-gh84RmKIPHJPdsX5Ugm_IHVJgF-Mmu_EgIDARo8CicAJQgCEiEDJS9w-QqgYTv6CHzhGYog8ck92xflSCb8gdUmAX4ya78QoemesAYaCwoJBES39Q2RAnVOKkYwRAIgLi3rouyaZFS_Uilx8k99ySdQCP1tsmLR21tDb9p8LcgCIG30o5YnEooQ1n6tgm9fCT7s53k6XlxyeSkD_uIO9mb3"
-    # BOOTSPR="spr:CiUIAhIhA6_j28xa--PvvOUxH10wKEm9feXEKJIK3Z9JQ5xXgSD9EgIDARo8CicAJQgCEiEDr-PbzFr74--85TEfXTAoSb195cQokgrdn0lDnFeBIP0QzOGesAYaCwoJBK6Kf1-RAnVEKkcwRQIhAPUH5nQrqG4OW86JQWphdSdnPA98ErQ0hL9OZH9a4e5kAiBBZmUl9KnhSOiDgU3_hvjXrXZXoMxhGuZ92_rk30sNDA"
-    # BOOTSPR="spr:CiUIAhIhA7E4DEMer8nUOIUSaNPA4z6x0n9Xaknd28Cfw9S2-cCeEgIDARo8CicAJQgCEiEDsTgMQx6vydQ4hRJo08DjPrHSf1dqSd3bwJ_D1Lb5wJ4Qt_CesAYaCwoJBEDhWZORAnVYKkYwRAIgFNzhnftocLlVHJl1onuhbSUM7MysXPV6dawHAA0DZNsCIDRVu9gnPTH5UkcRXLtt7MLHCo4-DL-RCMyTcMxYBXL0"
-    # BOOTSPR="spr:CiUIAhIhAzZn3JmJab46BNjadVnLNQKbhnN3eYxwqpteKYY32SbOEgIDARo8CicAJQgCEiEDNmfcmYlpvjoE2Np1Wcs1ApuGc3d5jHCqm14phjfZJs4QrvWesAYaCwoJBKpA-TaRAnViKkcwRQIhANuMmZDD2c25xzTbKSirEpkZYoxbq-FU_lpI0K0e4mIVAiBfQX4yR47h1LCnHznXgDs6xx5DLO5q3lUcicqUeaqGeg"
-    # BOOTSPR="spr:CiUIAhIhAgybmRwboqDdUJjeZrzh43sn5mp8jt6ENIb08tLn4x01EgIDARo8CicAJQgCEiECDJuZHBuioN1QmN5mvOHjeyfmanyO3oQ0hvTy0ufjHTUQh4ifsAYaCwoJBI_0zSiRAnVsKkcwRQIhAJCb_z0E3RsnQrEePdJzMSQrmn_ooHv6mbw1DOh5IbVNAiBbBJrWR8eBV6ftzMd6ofa5khNA2h88OBhMqHCIzSjCeA"
-    # BOOTSPR="spr:CiUIAhIhAntGLadpfuBCD9XXfiN_43-V3L5VWgFCXxg4a8uhDdnYEgIDARo8CicAJQgCEiECe0Ytp2l-4EIP1dd-I3_jf5XcvlVaAUJfGDhry6EN2dgQsIufsAYaCwoJBNEmoCiRAnV2KkYwRAIgXO3bzd5VF8jLZG8r7dcLJ_FnQBYp1BcxrOvovEa40acCIDhQ14eJRoPwJ6GKgqOkXdaFAsoszl-HIRzYcXKeb7D9"
-  fi
-fi
-
 if [ ! -f eth.key ]; then
   echo "eth.key does not exist. Please run generate.sh to create it."
   exit 1
 fi
 
 # Set variables
-VERSION="v0.1.6"
 OS=$(get_os)
 ARCH=$(get_arch)
 DATA_DIR="data_client"
@@ -44,16 +25,51 @@ DATA_DIR="data_client"
 mkdir -p ${DATA_DIR}
 chmod 0700 ${DATA_DIR}
 
-./codex-${VERSION}-${OS}-${ARCH} \
-  --data-dir=${DATA_DIR} \
-  --storage-quota=11811160064 \
-  --nat=${LOCALIP} \
-  --api-port=8080 \
-  --disc-port=8090 \
-  --listen-addrs=/ip4/0.0.0.0/tcp/8070 \
-  --bootstrap-node=${BOOTSPR} \
-  --api-cors-origin="*" \
-  --block-ttl=30d \
-  persistence \
-  --eth-private-key=eth.key \
-  --eth-provider=https://rpc.testnet.codex.storage
+# Run on workshop - Local network SPR (Workshop NUC)
+run_workshop() {
+  ./codex-${VERSION}-${OS}-${ARCH} \
+    --data-dir=${DATA_DIR} \
+    --storage-quota=11811160064 \
+    --nat=${LOCALIP} \
+    --api-port=8080 \
+    --disc-port=8090 \
+    --listen-addrs=/ip4/0.0.0.0/tcp/8070 \
+    --bootstrap-node=spr:CiUIAhIhAnBsex_7L5xKJQpmAuOtubQEtKsgCOXE2vaJoTJXrprbEgIDARo8CicAJQgCEiECcGx7H_svnEolCmYC4625tAS0qyAI5cTa9omhMleumtsQnbm0tAYaCwoJBMCoWP2RAh-aKkcwRQIhANjwAV9DGFe4zcMUEHjuTsGWAPc7WB7uoSS86HATwouqAiA8dFhsALCSLsQbSOPF1j7NF643oEmPEJAwU9dIwjM6TA \
+    --api-cors-origin="*" \
+    --block-ttl=30d \
+    --log-level=${LOG_LEVEL} \
+    persistence \
+    --eth-private-key=eth.key \
+    --eth-provider=https://rpc.testnet.codex.storage
+}
+
+# Run on testnet - All Codex Testnet Cloud Bootstrap Node SPRs
+run_testnet() {
+  ./codex-${VERSION}-${OS}-${ARCH} \
+    --data-dir=${DATA_DIR} \
+    --storage-quota=11811160064 \
+    --nat=${LOCALIP} \
+    --api-port=8080 \
+    --disc-port=8090 \
+    --listen-addrs=/ip4/0.0.0.0/tcp/8070 \
+    --bootstrap-node=spr:CiUIAhIhAiJvIcA_ZwPZ9ugVKDbmqwhJZaig5zKyLiuaicRcCGqLEgIDARo8CicAJQgCEiECIm8hwD9nA9n26BUoNuarCEllqKDnMrIuK5qJxFwIaosQ3d6esAYaCwoJBJ_f8zKRAnU6KkYwRAIgM0MvWNJL296kJ9gWvfatfmVvT-A7O2s8Mxp8l9c8EW0CIC-h-H-jBVSgFjg3Eny2u33qF7BDnWFzo7fGfZ7_qc9P \
+    --bootstrap-node=spr:CiUIAhIhAyUvcPkKoGE7-gh84RmKIPHJPdsX5Ugm_IHVJgF-Mmu_EgIDARo8CicAJQgCEiEDJS9w-QqgYTv6CHzhGYog8ck92xflSCb8gdUmAX4ya78QoemesAYaCwoJBES39Q2RAnVOKkYwRAIgLi3rouyaZFS_Uilx8k99ySdQCP1tsmLR21tDb9p8LcgCIG30o5YnEooQ1n6tgm9fCT7s53k6XlxyeSkD_uIO9mb3 \
+    --bootstrap-node=spr:CiUIAhIhA6_j28xa--PvvOUxH10wKEm9feXEKJIK3Z9JQ5xXgSD9EgIDARo8CicAJQgCEiEDr-PbzFr74--85TEfXTAoSb195cQokgrdn0lDnFeBIP0QzOGesAYaCwoJBK6Kf1-RAnVEKkcwRQIhAPUH5nQrqG4OW86JQWphdSdnPA98ErQ0hL9OZH9a4e5kAiBBZmUl9KnhSOiDgU3_hvjXrXZXoMxhGuZ92_rk30sNDA \
+    --bootstrap-node=spr:CiUIAhIhA7E4DEMer8nUOIUSaNPA4z6x0n9Xaknd28Cfw9S2-cCeEgIDARo8CicAJQgCEiEDsTgMQx6vydQ4hRJo08DjPrHSf1dqSd3bwJ_D1Lb5wJ4Qt_CesAYaCwoJBEDhWZORAnVYKkYwRAIgFNzhnftocLlVHJl1onuhbSUM7MysXPV6dawHAA0DZNsCIDRVu9gnPTH5UkcRXLtt7MLHCo4-DL-RCMyTcMxYBXL0 \
+    --bootstrap-node=spr:CiUIAhIhAzZn3JmJab46BNjadVnLNQKbhnN3eYxwqpteKYY32SbOEgIDARo8CicAJQgCEiEDNmfcmYlpvjoE2Np1Wcs1ApuGc3d5jHCqm14phjfZJs4QrvWesAYaCwoJBKpA-TaRAnViKkcwRQIhANuMmZDD2c25xzTbKSirEpkZYoxbq-FU_lpI0K0e4mIVAiBfQX4yR47h1LCnHznXgDs6xx5DLO5q3lUcicqUeaqGeg \
+    --bootstrap-node=spr:CiUIAhIhAgybmRwboqDdUJjeZrzh43sn5mp8jt6ENIb08tLn4x01EgIDARo8CicAJQgCEiECDJuZHBuioN1QmN5mvOHjeyfmanyO3oQ0hvTy0ufjHTUQh4ifsAYaCwoJBI_0zSiRAnVsKkcwRQIhAJCb_z0E3RsnQrEePdJzMSQrmn_ooHv6mbw1DOh5IbVNAiBbBJrWR8eBV6ftzMd6ofa5khNA2h88OBhMqHCIzSjCeA \
+    --bootstrap-node=spr:CiUIAhIhAntGLadpfuBCD9XXfiN_43-V3L5VWgFCXxg4a8uhDdnYEgIDARo8CicAJQgCEiECe0Ytp2l-4EIP1dd-I3_jf5XcvlVaAUJfGDhry6EN2dgQsIufsAYaCwoJBNEmoCiRAnV2KkYwRAIgXO3bzd5VF8jLZG8r7dcLJ_FnQBYp1BcxrOvovEa40acCIDhQ14eJRoPwJ6GKgqOkXdaFAsoszl-HIRzYcXKeb7D9 \
+    --api-cors-origin="*" \
+    --block-ttl=30d \
+    --log-level=${LOG_LEVEL} \
+    persistence \
+    --eth-private-key=eth.key \
+    --eth-provider=https://rpc.testnet.codex.storage
+}
+
+# Run the client
+if [ "${NETWORK}" == "workshop" ]; then
+  run_workshop
+elif [ "${NETWORK}" == "testnet" ]; then
+  run_testnet
+fi

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -2,6 +2,9 @@
 
 # Variables
 NETWORK="${NETWORK:-testnet}"
+VERSION="${VERSION:-v0.1.6}"
+LOG_LEVEL="${LOG_LEVEL:-info}"
+DOWNLOAD="${DOWNLOAD}"
 
 # Function to detect OS
 get_os() {


### PR DESCRIPTION
This PR add some improvements to the Linux/macOS scripts and .gitignore:
- Adds Codex artifacts to the `.gitignore`
- Use a single script for local and on-line download which is based on the `NETWORK`
   - now `download.sh = download_online.sh` and we can remove one in the future
- We can pass ethereum private key via `ETH_PRIVATE_KEY` var to skip online generation
- Use multiple bootstrap nodes for Codex Testnet
- We can pass a custom `LOG_LEVEL`
- Codex `VERSION` is defined using a variable in a single location

> [!NOTE]
> Windows scripts will be updated slightly later.

### Check
```shell
git clone https://github.com/codex-storage/codex-testnet-starter
cd codex-testnet-starter/scripts/

git switch -C feat/use-multiple-bootstrap-nodes origin/feat/use-multiple-bootstrap-nodes
```

#### Testnet
```shell
./download.sh

./generate.sh

./run_client.sh

LOG_LEVEL=debug ./run_client.sh
```

#### Workshop
```shell
NETWORK=workshop ./download.sh
DOWNLOAD=online ./download.sh  # if local fail, script will show that help message

ETH_PRIVATE_KEY=0x0fbc6086def0b9e877b20e34a586297d55eeecf36c7dc9f032e45fc9b6177349 ./generate.sh
./generate.sh

NETWORK=workshop ./run_client.sh
```

We also can export variables and do not pass them to every command
```shell
export NETWORK=workshop
export DOWNLOAD=online
export LOG_LEVEL=debug
```
