### PR TITLE
Use ETH_PRIVATE_KEY variable instead of deprecated PRIV_KEY

### DIFF
--- a/SETUP_HOME.md
+++ b/SETUP_HOME.md
@@ -111,7 +111,7 @@ The above options allow you to join the testnet, exchange data, and purchase sto
 >      - prover
 > ```
 > 📢 The Codex docker container will automatically find the public IP and use it. You can override this behavior by removing `NAT_PUBLIC_IP_AUTO` and setting `CODEX_NAT` manually.
-> 📢 When running in a container, option `--eth-private-key` can't be set to a key file outside of your container. To solve this, set the environment variable `PRIV_KEY` to the content of your private key file. Scripting inside the docker container will automatically write this to a file in the container, set the correct permissions, and pass it to Codex.
+> 📢 When running in a container, option `--eth-private-key` can't be set to a key file outside of your container. To solve this, set the environment variable `ETH_PRIVATE_KEY` to the content of your private key file. Scripting inside the docker container will automatically write this to a file in the container, set the correct permissions, and pass it to Codex.
 
 > 📢 Are you using Windows, and the "/" characters in the listen-addrs are giving you trouble?
 > In some shells, Windows will interpret "/" character as refering to "C:/" or the current working directory.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       - NAT_PUBLIC_IP_AUTO=https://ip.codex.storage
       - CODEX_ETH_PROVIDER=https://rpc.testnet.codex.storage/
       - CODEX_VALIDATOR=false
-      - PRIV_KEY=<<<PRIVATE_KEY_HERE>>>
+      - ETH_PRIVATE_KEY=<<<PRIVATE_KEY_HERE>>>
     ports:
       - 8080:8080/tcp # API
       - 8090:8090/udp # Discovery


### PR DESCRIPTION
A followup of the https://github.com/codex-storage/nim-codex/pull/982 and we updates the documentation to use a new variable.