### PR TITLE
Switch wallet to key generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Want to join the Codex Testnet? You can run it on your own hardware and from you
  - Codex API - [api.codex.storage](https://api.codex.storage)
  - Codex Discord - [discord.gg/codex-storage](https://discord.gg/codex-storage)
  - Block explorer - [explorer.testnet.codex.storage](https://explorer.testnet.codex.storage)
- - Web wallet - [wallet.testnet.codex.storage](https://wallet.testnet.codex.storage)
+ - Key generation - [key.codex.storage](https://key.codex.storage)
  - ETH faucet - [faucet-eth.testnet.codex.storage](https://faucet-eth.testnet.codex.storage)
  - TST facet - [faucet-tst.testnet.codex.storage](https://faucet-tst.testnet.codex.storage)
 


### PR DESCRIPTION
Some time ago, we switch from [wallet.testnet.codex.storage](https://wallet.testnet.codex.storage) to [key.codex.storage](https://key.codex.storage).

PR update the link in the main readme.