### PR TITLE
chore: update codex to release 0.2.0

### DIFF
--- a/SETUP_HOME.md
+++ b/SETUP_HOME.md
@@ -87,14 +87,14 @@ Several configuration options must be set correctly, so the node knows how to co
 
 These options are required to join the testnet:
  - `--bootstrap-node=SPR` - Set SPR to one of the Codex Testnet bootstrap node SPRs found [here](https://docs.codex.storage/networks/testnet)
- - `--nat=IP` - Set IP to your public IP address. Using Docker? Skip this one.
+ - `--nat=extip:IP` - Set IP to your public IP address. Using Docker? Skip this one.
  - `--listen-addrs=ADDR` - Set ADDR to "/ip4/0.0.0.0/tcp/8070". Note: If you changed the TCP port in the port forwarding step previously, change it here as well.
  - `--disc-port=PORT` - Set PORT to 8090. Again: If you changed it in the forward, do the same thing here.
  - `persistence` - Tells the node we want to enable marketplace interactions.
  - `--eth-private-key=FILE` - Set FILE to your private key file.
  - `--eth-provider=URL` - Set URL to the "Geth Public RPC" found [here](https://docs.codex.storage/networks/testnet)
 The marketplace address should default to the correct testnet deployment. You can override it with:
- - `--marketplace-address=ADDR` - Set ADDR to `0xAB03b6a58C5262f530D54146DA2a552B1C0F7648`
+ - `--marketplace-address=ADDR` - Set ADDR to `0xfFaF679D5Cbfdd5Dbc9Be61C616ed115DFb597ed`
 
 The above options allow you to join the testnet, exchange data, and purchase storage in the network. If you wish to *sell storage space* to the network, you must include one additional argument:
  - `prover` - Tells the node we want to enable storage space selling

--- a/codex.sh
+++ b/codex.sh
@@ -16,7 +16,7 @@ codex persistence \
   --metrics=true \
   --listen-addrs=/ip4/0.0.0.0/tcp/8070 \
   --disc-port=8090 \
-  --nat=$(curl https://ip.codex.storage) \
+  --nat=extip:$(curl https://ip.codex.storage) \
   --circuit-dir=./codex-data/circuits \
   --eth-private-key=eth.key \
   --eth-provider=https://rpc.testnet.codex.storage

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   # Codex Node
   codex:
-    image: codexstorage/nim-codex:0.1.8
+    image: codexstorage/nim-codex:0.2.0
     container_name: codex
     command:
       - codex

--- a/forcodexers/run_host.sh
+++ b/forcodexers/run_host.sh
@@ -17,7 +17,7 @@ BOOTSPR=$(curl http://localhost:8078/api/codex/v1/spr | cut -d '"' -f4)
   persistence \
   --eth-private-key=eth.key \
   --eth-provider=https://rpc.testnet.codex.storage \
-  --marketplace-address=0xAB03b6a58C5262f530D54146DA2a552B1C0F7648 \
+  --marketplace-address=0xfFaF679D5Cbfdd5Dbc9Be61C616ed115DFb597ed \
   prover \
   &
 

--- a/scripts/run_client.sh
+++ b/scripts/run_client.sh
@@ -30,7 +30,7 @@ run_workshop() {
   ./codex-${VERSION}-${OS}-${ARCH} \
     --data-dir=${DATA_DIR} \
     --storage-quota=11811160064 \
-    --nat=${LOCALIP} \
+    --nat=extip:${LOCALIP} \
     --api-port=8080 \
     --disc-port=8090 \
     --listen-addrs=/ip4/0.0.0.0/tcp/8070 \
@@ -48,7 +48,7 @@ run_testnet() {
   ./codex-${VERSION}-${OS}-${ARCH} \
     --data-dir=${DATA_DIR} \
     --storage-quota=11811160064 \
-    --nat=${LOCALIP} \
+    --nat=extip:${LOCALIP} \
     --api-port=8080 \
     --disc-port=8090 \
     --listen-addrs=/ip4/0.0.0.0/tcp/8070 \

--- a/scripts/run_testnet.sh
+++ b/scripts/run_testnet.sh
@@ -13,7 +13,7 @@ chmod 0700 ${DATA_DIR}
 ./codex \
   --data-dir=${DATA_DIR} \
   --storage-quota=11811160064 \
-  --nat=${PUBLICIP} \
+  --nat=extip:${PUBLICIP} \
   --api-port=8080 \
   --disc-port=8090 \
   --listen-addrs=/ip4/0.0.0.0/tcp/8070 \

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -2,7 +2,7 @@
 
 # Variables
 NETWORK="${NETWORK:-testnet}"
-VERSION="${VERSION:-v0.1.9}"
+VERSION="${VERSION:-v0.2.0}"
 LOG_LEVEL="${LOG_LEVEL:-info}"
 DOWNLOAD="${DOWNLOAD}"
 

--- a/scripts/windows/download-online.bat
+++ b/scripts/windows/download-online.bat
@@ -9,7 +9,7 @@ set "OS=windows"
 call :get_arch ARCH
 set "ARCHIVE_EXT=.zip"
 set "EXE_EXT=.exe"
-set "VERSION=v0.1.9"
+set "VERSION=v0.2.0"
 set "BASE_URL=https://github.com/codex-storage/nim-codex/releases/download/%VERSION%"
 set "EXTRACT_DIR=.\"
 set "BINARY_NAMES=codex"

--- a/scripts/windows/download.bat
+++ b/scripts/windows/download.bat
@@ -9,7 +9,7 @@ set "OS=windows"
 call :get_arch ARCH
 set "ARCHIVE_EXT=.zip"
 set "EXE_EXT=.exe"
-set "VERSION=v0.1.9"
+set "VERSION=v0.2.0"
 set "BASE_URL=http://192.168.88.253:8080"
 set "EXTRACT_DIR=.\"
 set "BINARY_NAMES=codex"

--- a/scripts/windows/run-client.bat
+++ b/scripts/windows/run-client.bat
@@ -44,7 +44,7 @@ if errorlevel 1 (
 )
 
 :: Set variables
-set "VERSION=v0.1.9"
+set "VERSION=v0.2.0"
 set "OS=windows"
 call :get_arch ARCH
 set "DATA_DIR=data_client"
@@ -56,7 +56,7 @@ icacls %DATA_DIR% /grant:r %USERNAME%:(OI)(CI)F
 codex-%VERSION%-%OS%-%ARCH%.exe ^
     --data-dir=%DATA_DIR% ^
     --storage-quota=11811160064 ^
-    --nat=%LOCALIP% ^
+    --nat=extip:%LOCALIP% ^
     --api-port=8080 ^
     --disc-port=8090 ^
     --listen-addrs=/ip4/0.0.0.0/tcp/8070 ^


### PR DESCRIPTION
PR updates the scripts to use the latest Codex release 0.2.0 and new Marketplace address for Testnet.

Part of https://github.com/codex-storage/nim-codex/issues/1126.