### PR TITLE
chore: update codex to release 0.2.3

### DIFF
--- a/SETUP_HOME.md
+++ b/SETUP_HOME.md
@@ -94,7 +94,7 @@ These options are required to join the testnet:
  - `--eth-private-key=FILE` - Set FILE to your private key file.
  - `--eth-provider=URL` - Set URL to the "Geth Public RPC" found [here](https://docs.codex.storage/networks/testnet)
 The marketplace address should default to the correct testnet deployment. You can override it with:
- - `--marketplace-address=ADDR` - Set ADDR to `0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3`
+ - `--marketplace-address=ADDR` - Set ADDR to `0x7c7a749DE7156305E55775e7Ab3931abd6f7300E`
 
 The above options allow you to join the testnet, exchange data, and purchase storage in the network. If you wish to *sell storage space* to the network, you must include one additional argument:
  - `prover` - Tells the node we want to enable storage space selling

--- a/forcodexers/docker-compose.yaml
+++ b/forcodexers/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       - CODEX_VALIDATOR=false
 
       # Update me. Required for circuit downloader:
-      - CODEX_MARKETPLACE_ADDRESS=0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3
+      - CODEX_MARKETPLACE_ADDRESS=0x7c7a749DE7156305E55775e7Ab3931abd6f7300E
       - PRIV_KEY=<<< PRIVATE KEY HERE >>>
     ports:
       - "8081:8081/tcp"

--- a/forcodexers/run_host.sh
+++ b/forcodexers/run_host.sh
@@ -17,7 +17,7 @@ BOOTSPR=$(curl http://localhost:8078/api/codex/v1/spr | cut -d '"' -f4)
   persistence \
   --eth-private-key=eth.key \
   --eth-provider=https://rpc.testnet.codex.storage \
-  --marketplace-address=0xDB2908d724a15d05c0B6B8e8441a8b36E67476d3 \
+  --marketplace-address=0x7c7a749DE7156305E55775e7Ab3931abd6f7300E \
   prover \
   &
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -2,7 +2,7 @@
 
 # Variables
 NETWORK="${NETWORK:-testnet}"
-VERSION="${VERSION:-v0.2.1}"
+VERSION="${VERSION:-v0.2.3}"
 LOG_LEVEL="${LOG_LEVEL:-info}"
 DOWNLOAD="${DOWNLOAD}"
 

--- a/scripts/windows/download-online.bat
+++ b/scripts/windows/download-online.bat
@@ -9,7 +9,7 @@ set "OS=windows"
 call :get_arch ARCH
 set "ARCHIVE_EXT=.zip"
 set "EXE_EXT=.exe"
-set "VERSION=v0.2.1"
+set "VERSION=v0.2.3"
 set "BASE_URL=https://github.com/codex-storage/nim-codex/releases/download/%VERSION%"
 set "EXTRACT_DIR=.\"
 set "BINARY_NAMES=codex"

--- a/scripts/windows/download.bat
+++ b/scripts/windows/download.bat
@@ -9,7 +9,7 @@ set "OS=windows"
 call :get_arch ARCH
 set "ARCHIVE_EXT=.zip"
 set "EXE_EXT=.exe"
-set "VERSION=v0.2.1"
+set "VERSION=v0.2.3"
 set "BASE_URL=http://192.168.88.253:8080"
 set "EXTRACT_DIR=.\"
 set "BINARY_NAMES=codex"

--- a/scripts/windows/run-client.bat
+++ b/scripts/windows/run-client.bat
@@ -44,7 +44,7 @@ if errorlevel 1 (
 )
 
 :: Set variables
-set "VERSION=v0.2.1"
+set "VERSION=v0.2.3"
 set "OS=windows"
 call :get_arch ARCH
 set "DATA_DIR=data_client"


### PR DESCRIPTION
PR updates the scripts to use the latest Codex release 0.2.3 and new Marketplace address for Testnet.

Part of https://github.com/codex-storage/nim-codex/issues/1241.