### PR TITLE
chore: update codex to release 0.2.4

### DIFF
--- a/SETUP_HOME.md
+++ b/SETUP_HOME.md
@@ -94,7 +94,7 @@ These options are required to join the testnet:
  - `--eth-private-key=FILE` - Set FILE to your private key file.
  - `--eth-provider=URL` - Set URL to the "Geth Public RPC" found [here](https://docs.codex.storage/networks/testnet)
 The marketplace address should default to the correct testnet deployment. You can override it with:
- - `--marketplace-address=ADDR` - Set ADDR to `0x7c7a749DE7156305E55775e7Ab3931abd6f7300E`
+ - `--marketplace-address=ADDR` - Set ADDR to a specific address like `0x0000000000000000000000000000000000000000`
 
 The above options allow you to join the testnet, exchange data, and purchase storage in the network. If you wish to *sell storage space* to the network, you must include one additional argument:
  - `prover` - Tells the node we want to enable storage space selling

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,33 +1,29 @@
 services:
-  # Codex Node
   codex:
-    image: codexstorage/nim-codex:0.2.1
+    image: codexstorage/nim-codex:stable
+    pull_policy: always
     container_name: codex
     command:
       - codex
       - persistence
       # - prover # Uncomment this to enable storage proof generator.
-      - --bootstrap-node=spr:CiUIAhIhAiJvIcA_ZwPZ9ugVKDbmqwhJZaig5zKyLiuaicRcCGqLEgIDARo8CicAJQgCEiECIm8hwD9nA9n26BUoNuarCEllqKDnMrIuK5qJxFwIaosQ3d6esAYaCwoJBJ_f8zKRAnU6KkYwRAIgM0MvWNJL296kJ9gWvfatfmVvT-A7O2s8Mxp8l9c8EW0CIC-h-H-jBVSgFjg3Eny2u33qF7BDnWFzo7fGfZ7_qc9P
-      - --bootstrap-node=spr:CiUIAhIhAyUvcPkKoGE7-gh84RmKIPHJPdsX5Ugm_IHVJgF-Mmu_EgIDARo8CicAJQgCEiEDJS9w-QqgYTv6CHzhGYog8ck92xflSCb8gdUmAX4ya78QoemesAYaCwoJBES39Q2RAnVOKkYwRAIgLi3rouyaZFS_Uilx8k99ySdQCP1tsmLR21tDb9p8LcgCIG30o5YnEooQ1n6tgm9fCT7s53k6XlxyeSkD_uIO9mb3
-      - --bootstrap-node=spr:CiUIAhIhAlNJ7ary8eOK5GcwQ6q4U8brR7iWjwhMwzHb8BzzmCEDEgIDARpJCicAJQgCEiECU0ntqvLx44rkZzBDqrhTxutHuJaPCEzDMdvwHPOYIQMQsZ67vgYaCwoJBK6Kf1-RAnVEGgsKCQSuin9fkQJ1RCpGMEQCIDxd6lXDvj1PcHgQYnNpHGfgCO5a7fejg3WhSjh2wTimAiB7YHsL1WZYU_zkHcNDWhRgMbkb3C5yRuvUhjBjGOYJYQ
-      - --bootstrap-node=spr:CiUIAhIhA7E4DEMer8nUOIUSaNPA4z6x0n9Xaknd28Cfw9S2-cCeEgIDARo8CicAJQgCEiEDsTgMQx6vydQ4hRJo08DjPrHSf1dqSd3bwJ_D1Lb5wJ4Qt_CesAYaCwoJBEDhWZORAnVYKkYwRAIgFNzhnftocLlVHJl1onuhbSUM7MysXPV6dawHAA0DZNsCIDRVu9gnPTH5UkcRXLtt7MLHCo4-DL-RCMyTcMxYBXL0
-      - --bootstrap-node=spr:CiUIAhIhAzZn3JmJab46BNjadVnLNQKbhnN3eYxwqpteKYY32SbOEgIDARo8CicAJQgCEiEDNmfcmYlpvjoE2Np1Wcs1ApuGc3d5jHCqm14phjfZJs4QrvWesAYaCwoJBKpA-TaRAnViKkcwRQIhANuMmZDD2c25xzTbKSirEpkZYoxbq-FU_lpI0K0e4mIVAiBfQX4yR47h1LCnHznXgDs6xx5DLO5q3lUcicqUeaqGeg
-      - --bootstrap-node=spr:CiUIAhIhAuN-P1D0HrJdwBmrRlZZzg6dqllRNNcQyMDUMuRtg3paEgIDARpJCicAJQgCEiEC434_UPQesl3AGatGVlnODp2qWVE01xDIwNQy5G2DeloQm_L2vQYaCwoJBI_0zSiRAnVsGgsKCQSP9M0okQJ1bCpHMEUCIQDgEVjUp1RJGb59eRPs7RPYMSGAI_fo1yv70iBtnTqefQIgVoXszc87EGFVO3aaqorEYZ21OGRko5ho_Pybdyqa6AI
-      - --bootstrap-node=spr:CiUIAhIhAsi_hgxFppWjHiKRwnYPX_qkB28dLtwK9c7apnlBanFuEgIDARpJCicAJQgCEiECyL-GDEWmlaMeIpHCdg9f-qQHbx0u3Ar1ztqmeUFqcW4Q2O32vQYaCwoJBNEmoCiRAnV2GgsKCQTRJqAokQJ1dipHMEUCIQDpC1isFfdRqNmZBfz9IGoEq7etlypB6N1-9Z5zhvmRMAIgIOsleOPr5Ra_Nk7BXmXGhe-YlLosH9jo83JtfWCy3-o
     environment:
+      - NETWORK=testnet
       - CODEX_DATA_DIR=/data
       - CODEX_API_PORT=8080
       - CODEX_API_BINDADDR=0.0.0.0
+      - CODEX_API_CORS_ORIGIN="*"
       - CODEX_LISTEN_ADDRS=/ip4/0.0.0.0/tcp/8070
       - CODEX_DISC_PORT=8090
       - NAT_PUBLIC_IP_AUTO=https://ip.codex.storage
-      - CODEX_ETH_PROVIDER=https://rpc.testnet.codex.storage/
+      - CODEX_ETH_PROVIDER=https://rpc.testnet.codex.storage
       - CODEX_VALIDATOR=false
-      - ETH_PRIVATE_KEY=<<<PRIVATE_KEY_HERE>>>
+      # Update or export a variable with a private key value
+      - ETH_PRIVATE_KEY=${ETH_PRIVATE_KEY:-<<< PRIVATE KEY HERE >>>}
     ports:
       - 8080:8080/tcp # API
-      - 8090:8090/udp # Discovery
       - 8070:8070/tcp # Transport
+      - 8090:8090/udp # Discovery
     volumes:
       - ./codex-data:/data
     logging:

--- a/forcodexers/docker-compose.yaml
+++ b/forcodexers/docker-compose.yaml
@@ -1,38 +1,30 @@
 services:
   codex-dist-test:
-    image: codexstorage/nim-codex:0.2.2-dist-tests
+    image: codexstorage/nim-codex:stable-dist-tests
+    pull_policy: always
     container_name: codex
     command:
       - codex
       - persistence
       - prover
-      - --api-cors-origin=*
-      - --bootstrap-node=spr:CiUIAhIhAiJvIcA_ZwPZ9ugVKDbmqwhJZaig5zKyLiuaicRcCGqLEgIDARo8CicAJQgCEiECIm8hwD9nA9n26BUoNuarCEllqKDnMrIuK5qJxFwIaosQ3d6esAYaCwoJBJ_f8zKRAnU6KkYwRAIgM0MvWNJL296kJ9gWvfatfmVvT-A7O2s8Mxp8l9c8EW0CIC-h-H-jBVSgFjg3Eny2u33qF7BDnWFzo7fGfZ7_qc9P
-      - --bootstrap-node=spr:CiUIAhIhAyUvcPkKoGE7-gh84RmKIPHJPdsX5Ugm_IHVJgF-Mmu_EgIDARo8CicAJQgCEiEDJS9w-QqgYTv6CHzhGYog8ck92xflSCb8gdUmAX4ya78QoemesAYaCwoJBES39Q2RAnVOKkYwRAIgLi3rouyaZFS_Uilx8k99ySdQCP1tsmLR21tDb9p8LcgCIG30o5YnEooQ1n6tgm9fCT7s53k6XlxyeSkD_uIO9mb3
-      - --bootstrap-node=spr:CiUIAhIhAlNJ7ary8eOK5GcwQ6q4U8brR7iWjwhMwzHb8BzzmCEDEgIDARpJCicAJQgCEiECU0ntqvLx44rkZzBDqrhTxutHuJaPCEzDMdvwHPOYIQMQsZ67vgYaCwoJBK6Kf1-RAnVEGgsKCQSuin9fkQJ1RCpGMEQCIDxd6lXDvj1PcHgQYnNpHGfgCO5a7fejg3WhSjh2wTimAiB7YHsL1WZYU_zkHcNDWhRgMbkb3C5yRuvUhjBjGOYJYQ
-      - --bootstrap-node=spr:CiUIAhIhA7E4DEMer8nUOIUSaNPA4z6x0n9Xaknd28Cfw9S2-cCeEgIDARo8CicAJQgCEiEDsTgMQx6vydQ4hRJo08DjPrHSf1dqSd3bwJ_D1Lb5wJ4Qt_CesAYaCwoJBEDhWZORAnVYKkYwRAIgFNzhnftocLlVHJl1onuhbSUM7MysXPV6dawHAA0DZNsCIDRVu9gnPTH5UkcRXLtt7MLHCo4-DL-RCMyTcMxYBXL0
-      - --bootstrap-node=spr:CiUIAhIhAzZn3JmJab46BNjadVnLNQKbhnN3eYxwqpteKYY32SbOEgIDARo8CicAJQgCEiEDNmfcmYlpvjoE2Np1Wcs1ApuGc3d5jHCqm14phjfZJs4QrvWesAYaCwoJBKpA-TaRAnViKkcwRQIhANuMmZDD2c25xzTbKSirEpkZYoxbq-FU_lpI0K0e4mIVAiBfQX4yR47h1LCnHznXgDs6xx5DLO5q3lUcicqUeaqGeg
-      - --bootstrap-node=spr:CiUIAhIhAuN-P1D0HrJdwBmrRlZZzg6dqllRNNcQyMDUMuRtg3paEgIDARpJCicAJQgCEiEC434_UPQesl3AGatGVlnODp2qWVE01xDIwNQy5G2DeloQm_L2vQYaCwoJBI_0zSiRAnVsGgsKCQSP9M0okQJ1bCpHMEUCIQDgEVjUp1RJGb59eRPs7RPYMSGAI_fo1yv70iBtnTqefQIgVoXszc87EGFVO3aaqorEYZ21OGRko5ho_Pybdyqa6AI
-      - --bootstrap-node=spr:CiUIAhIhAsi_hgxFppWjHiKRwnYPX_qkB28dLtwK9c7apnlBanFuEgIDARpJCicAJQgCEiECyL-GDEWmlaMeIpHCdg9f-qQHbx0u3Ar1ztqmeUFqcW4Q2O32vQYaCwoJBNEmoCiRAnV2GgsKCQTRJqAokQJ1dipHMEUCIQDpC1isFfdRqNmZBfz9IGoEq7etlypB6N1-9Z5zhvmRMAIgIOsleOPr5Ra_Nk7BXmXGhe-YlLosH9jo83JtfWCy3-o
     environment:
+      - NETWORK=testnet
       - CODEX_DATA_DIR=/data
       - CODEX_CIRCUIT_DIR=/circuit
       - CODEX_API_PORT=8080
       - CODEX_API_BINDADDR=0.0.0.0
-      - CODEX_LISTEN_ADDRS=/ip4/0.0.0.0/tcp/8070
       - CODEX_API_CORS_ORIGIN="*"
+      - CODEX_LISTEN_ADDRS=/ip4/0.0.0.0/tcp/8070
       - CODEX_DISC_PORT=8090
       - NAT_PUBLIC_IP_AUTO=https://ip.codex.storage
-      - CODEX_ETH_PROVIDER=https://rpc.testnet.codex.storage/
+      - CODEX_ETH_PROVIDER=https://rpc.testnet.codex.storage
       - CODEX_VALIDATOR=false
-
-      # Update me. Required for circuit downloader:
-      - CODEX_MARKETPLACE_ADDRESS=0x7c7a749DE7156305E55775e7Ab3931abd6f7300E
-      - PRIV_KEY=<<< PRIVATE KEY HERE >>>
+      # Update or export a variable with a private key value
+      - ETH_PRIVATE_KEY=${ETH_PRIVATE_KEY:-<<< PRIVATE KEY HERE >>>}
     ports:
-      - "8081:8081/tcp"
-      - "8070:8070/tcp"
-      - "8090:8090/udp"
+      - 8081:8081/tcp # API
+      - 8070:8070/tcp # Transport
+      - 8090:8090/udp # Discovery
     volumes:
       - ./codex-data:/data
       - ./codex-circuit:/circuit

--- a/forcodexers/run_host.sh
+++ b/forcodexers/run_host.sh
@@ -5,7 +5,7 @@ BOOTSPR=$(curl http://localhost:8078/api/codex/v1/spr | cut -d '"' -f4)
 # Quota = 11 GB
 # Availability = 10 GB
 
-./codex-prover-v0.1.3-linux-amd64 \
+./codex-prover-v0.2.4-linux-amd64 \
   --data-dir=data_host \
   --circuit-dir=circuit \
   --storage-quota=11811160064 \
@@ -17,7 +17,6 @@ BOOTSPR=$(curl http://localhost:8078/api/codex/v1/spr | cut -d '"' -f4)
   persistence \
   --eth-private-key=eth.key \
   --eth-provider=https://rpc.testnet.codex.storage \
-  --marketplace-address=0x7c7a749DE7156305E55775e7Ab3931abd6f7300E \
   prover \
   &
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -2,7 +2,7 @@
 
 # Variables
 NETWORK="${NETWORK:-testnet}"
-VERSION="${VERSION:-v0.2.3}"
+VERSION="${VERSION:-v0.2.4}"
 LOG_LEVEL="${LOG_LEVEL:-info}"
 DOWNLOAD="${DOWNLOAD}"
 

--- a/scripts/windows/download-online.bat
+++ b/scripts/windows/download-online.bat
@@ -9,7 +9,7 @@ set "OS=windows"
 call :get_arch ARCH
 set "ARCHIVE_EXT=.zip"
 set "EXE_EXT=.exe"
-set "VERSION=v0.2.3"
+set "VERSION=v0.2.4"
 set "BASE_URL=https://github.com/codex-storage/nim-codex/releases/download/%VERSION%"
 set "EXTRACT_DIR=.\"
 set "BINARY_NAMES=codex"

--- a/scripts/windows/download.bat
+++ b/scripts/windows/download.bat
@@ -9,7 +9,7 @@ set "OS=windows"
 call :get_arch ARCH
 set "ARCHIVE_EXT=.zip"
 set "EXE_EXT=.exe"
-set "VERSION=v0.2.3"
+set "VERSION=v0.2.4"
 set "BASE_URL=http://192.168.88.253:8080"
 set "EXTRACT_DIR=.\"
 set "BINARY_NAMES=codex"

--- a/scripts/windows/run-client.bat
+++ b/scripts/windows/run-client.bat
@@ -44,7 +44,7 @@ if errorlevel 1 (
 )
 
 :: Set variables
-set "VERSION=v0.2.3"
+set "VERSION=v0.2.4"
 set "OS=windows"
 call :get_arch ARCH
 set "DATA_DIR=data_client"


### PR DESCRIPTION
PR updates the scripts to use the latest Codex release 0.2.4 and remove reference to the Marketplace address, as we already have auto-discovery in `cirdl` as well - https://github.com/codex-storage/nim-codex/pull/1259.

Also, we recently deprecated `PRIV_KEY` variable - https://github.com/codex-storage/nim-codex/pull/1271.

Docker compose files were updated/synched and switched to use a `stable` tag and `NETWORK` variable to automatically set bootstrap nodes.

Part of https://github.com/codex-storage/nim-codex/issues/1269.