### PR TITLE
chore: update codex to release 0.2.5

### DIFF
--- a/forcodexers/run_host.sh
+++ b/forcodexers/run_host.sh
@@ -5,7 +5,7 @@ BOOTSPR=$(curl http://localhost:8078/api/codex/v1/spr | cut -d '"' -f4)
 # Quota = 11 GB
 # Availability = 10 GB
 
-./codex-prover-v0.2.4-linux-amd64 \
+./codex-prover-v0.2.5-linux-amd64 \
   --data-dir=data_host \
   --circuit-dir=circuit \
   --storage-quota=11811160064 \

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -2,7 +2,7 @@
 
 # Variables
 NETWORK="${NETWORK:-testnet}"
-VERSION="${VERSION:-v0.2.4}"
+VERSION="${VERSION:-v0.2.5}"
 LOG_LEVEL="${LOG_LEVEL:-info}"
 DOWNLOAD="${DOWNLOAD}"
 

--- a/scripts/windows/download-online.bat
+++ b/scripts/windows/download-online.bat
@@ -9,7 +9,7 @@ set "OS=windows"
 call :get_arch ARCH
 set "ARCHIVE_EXT=.zip"
 set "EXE_EXT=.exe"
-set "VERSION=v0.2.4"
+set "VERSION=v0.2.5"
 set "BASE_URL=https://github.com/codex-storage/nim-codex/releases/download/%VERSION%"
 set "EXTRACT_DIR=.\"
 set "BINARY_NAMES=codex"

--- a/scripts/windows/download.bat
+++ b/scripts/windows/download.bat
@@ -9,7 +9,7 @@ set "OS=windows"
 call :get_arch ARCH
 set "ARCHIVE_EXT=.zip"
 set "EXE_EXT=.exe"
-set "VERSION=v0.2.4"
+set "VERSION=v0.2.5"
 set "BASE_URL=http://192.168.88.253:8080"
 set "EXTRACT_DIR=.\"
 set "BINARY_NAMES=codex"

--- a/scripts/windows/run-client.bat
+++ b/scripts/windows/run-client.bat
@@ -44,7 +44,7 @@ if errorlevel 1 (
 )
 
 :: Set variables
-set "VERSION=v0.2.4"
+set "VERSION=v0.2.5"
 set "OS=windows"
 call :get_arch ARCH
 set "DATA_DIR=data_client"


### PR DESCRIPTION
PR updates the scripts to use the latest Codex release 0.2.5.

Part of https://github.com/codex-storage/nim-codex/issues/1282.